### PR TITLE
Fix/alpha6 compile errors

### DIFF
--- a/addons/tbloader/tbloader.gdextension
+++ b/addons/tbloader/tbloader.gdextension
@@ -3,5 +3,5 @@ entry_symbol = "tbloader_init"
 
 [libraries]
 windows.64 = "bin/tbloader.windows.64.dll"
-linux.64 = "bin/tbloader.linux.64.so"
+linux.64 = "bin/libtbloader.linux.64.so"
 macos.64 = "bin/libtbloader.framework"

--- a/src/tb_loader.h
+++ b/src/tb_loader.h
@@ -9,6 +9,7 @@
 #include <godot_cpp/classes/control.hpp>
 
 #include <builder.h>
+#include <cstring>
 
 using namespace godot;
 


### PR DESCRIPTION
`cstring` headers are missing and adding to `tb_loader.h` seems to be enough to resolve it.

For some reason the library file created on Linux is `libtbloader.linux.64.so`. I couldn't find where or why it was doing that so I've changed the `gdextension` file to point to the file actually created.

Happy for this to be rejected. The goal was to show more of the changes I made to get it to compile and load. Unfortunately I've only managed to import a map file once and now Godot crashes each time.