### PR TITLE
add support for materials

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,6 +48,11 @@ which will have some common entities that create Godot nodes. Simply place the f
 called `Godot` inside the `games` folder of your TrenchBroom installation, so you would have
 `games/Godot/<files>`.
 
+# Textures
+To see your textures in TrenchBroom, navigate to `Preferences` -> `Godot` -> `Game Path` and set it to your project's root directory. TrenchBroom will be able to see textures in your project. TBLoader will look for your textures in the `res://textures` directory. If you have a material (`rust.material`) in the same folder and with the same name as your texture (`rust.png`), TBLoader will load your material instead.
+
+> Note: This currently only works with textures in `.png` format, and materials in `.material` format
+
 # Credits
 * [Qodot](https://github.com/QodotPlugin/qodot-plugin)
 * [Original libmap](https://github.com/QodotPlugin/libmap)

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -336,9 +336,27 @@ String Builder::texture_path(const char* name)
 	return String("res://textures/") + name + ".png";
 }
 
+String Builder::material_path(const char* name)
+{
+	//TODO: .material might not always be correct!
+	return String("res://textures/") + name + ".material";
+}
+
 Ref<Texture2D> Builder::texture_from_name(const char* name)
 {
 	auto path = texture_path(name);
+
+	auto resource_loader = ResourceLoader::get_singleton();
+	if (!resource_loader->exists(path)) {
+		return nullptr;
+	}
+
+	return resource_loader->load(path);
+}
+
+Ref<StandardMaterial3D> Builder::material_from_name(const char* name)
+{
+	auto path = material_path(name);
 
 	auto resource_loader = ResourceLoader::get_singleton();
 	if (!resource_loader->exists(path)) {

--- a/src/builder.h
+++ b/src/builder.h
@@ -5,6 +5,7 @@
 
 #include <godot_cpp/classes/file.hpp>
 #include <godot_cpp/classes/texture2d.hpp>
+#include <godot_cpp/classes/standard_material3d.hpp>
 #include <godot_cpp/classes/array_mesh.hpp>
 #include <godot_cpp/classes/node3d.hpp>
 
@@ -45,5 +46,7 @@ protected:
 
 protected:
 	static String texture_path(const char* name);
+  static String material_path(const char* name);
 	static Ref<Texture2D> texture_from_name(const char* name);
+	static Ref<StandardMaterial3D> material_from_name(const char* name);
 };

--- a/src/builders/mesh_builder.cpp
+++ b/src/builders/mesh_builder.cpp
@@ -51,21 +51,31 @@ void MeshBuilder::build_worldspawn(int idx, LMEntity& ent, LMEntityGeometry& geo
 
 void MeshBuilder::build_texture_mesh(int idx, const char* name, LMEntity& ent, Node3D* parent)
 {
-	// Load texture
-	auto res_texture = texture_from_name(name);
-
-	// Use texture as name for the mesh instance
-	String instance_name = String(name).replace("/", "_");
-
 	// Create material
 	Ref<StandardMaterial3D> material;
-	if (res_texture != nullptr) {
-		material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D()));
-		material->set_texture(BaseMaterial3D::TEXTURE_ALBEDO, res_texture);
-		if (m_loader->m_filter_nearest) {
-			material->set_texture_filter(BaseMaterial3D::TEXTURE_FILTER_NEAREST);
-		}
-	}
+
+  // Use name for the mesh instance
+  String instance_name = String(name).replace("/", "_");
+
+	// Attempt to load material
+	auto res_material = material_from_name(name);
+
+  if (res_material != nullptr) {
+    // Set material
+    material = res_material;
+  } else {
+    // Load texture
+    auto res_texture = texture_from_name(name);
+
+    // Create material
+    if (res_texture != nullptr) {
+      material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D()));
+      material->set_texture(BaseMaterial3D::TEXTURE_ALBEDO, res_texture);
+      if (m_loader->m_filter_nearest) {
+        material->set_texture_filter(BaseMaterial3D::TEXTURE_FILTER_NEAREST);
+      }
+    }
+  }
 
 	// Gather surfaces for this texture
 	LMSurfaceGatherer surf_gather(m_map);


### PR DESCRIPTION
adds support for custom materials based on texture name, meaning we can do stuff like set values for metallic textures to be actually metallic, selectively choose nearest neighbor, other material stuff - without having to reapply after rebuilding the mesh in godot