### PR TITLE
Check for .tres material if no .material file exists

### DIFF
--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -548,7 +548,7 @@ String Builder::texture_path(const char* name)
 String Builder::material_path(const char* name)
 {
 	auto root_path = String("res://textures/") + name;
-	auto material_path = String();
+	String material_path;
 	
 	File f;
 

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -547,8 +547,18 @@ String Builder::texture_path(const char* name)
 
 String Builder::material_path(const char* name)
 {
-	//TODO: .material might not always be correct!
-	return String("res://textures/") + name + ".material";
+	auto root_path = String("res://textures/") + name;
+	auto material_path = String();
+	
+	File f;
+
+	if (f.file_exists(root_path + ".material")) {
+		material_path = root_path + ".material";
+	} else if (f.file_exists(root_path + ".tres")) {
+		material_path = root_path + ".tres";
+	}
+
+	return material_path;
 }
 
 Ref<Texture2D> Builder::texture_from_name(const char* name)


### PR DESCRIPTION
Just a quick fix to add the ability for the plugin to utilize `.tres` materials if it doesn't find a `.material`. Not sure if it's a reasonably good implementation or if you wanted to do this differently, but I was having issues with #15 since I use `.tres` exclusively (for version control purposes), and wanted to get that working to use for my project!