### PR TITLE
Various brush entity improvements and fixes

### DIFF
--- a/src/builder.h
+++ b/src/builder.h
@@ -9,6 +9,8 @@
 #include <godot_cpp/classes/array_mesh.hpp>
 #include <godot_cpp/classes/node3d.hpp>
 #include <godot_cpp/classes/area3d.hpp>
+#include <godot_cpp/classes/mesh_instance3d.hpp>
+
 
 #include <map_parser.h>
 #include <geo_generator.h>
@@ -64,8 +66,8 @@ protected:
 	Vector3 lm_transform(const vec3& v);
 
 	void add_collider_from_mesh(Node3D* area, Ref<ArrayMesh>& mesh, ColliderShape colshape);
-	Ref<ArrayMesh> create_mesh_from_surface(LMSurface& surf);
-	void build_texture_mesh(int idx, const char* name, LMEntity& ent, Node3D* parent, ColliderType coltype, ColliderShape colshape);
+	void add_surface_to_mesh(Ref<ArrayMesh>& mesh, LMSurface& surf);
+	MeshInstance3D* build_entity_mesh(int idx, LMEntity& ent, Node3D* parent, ColliderType coltype, ColliderShape colshape);
 
 protected:
 	static String texture_path(const char* name);


### PR DESCRIPTION
This includes:
- Generate one mesh instance per entity, instead of one mesh instance per texture, this seems like a much more sensible way than using one meshinstance per texture
- Fix the rotation of brush entities, previously the transform was applied on top, however this is wrong as the brush entity's geometry is already in godot space (and brush entities have no rotation anyways).
- Always generate visuals for brush entities, this is because a brush entity doesn't have to make use of collision at all
- Generate brush entity collisions as siblings of the mesh instance if the brush entity is of a physics type, this is so the parent is the one that handles all the physics of the brush entity