### PR TITLE
Add ability to set a visual layer mask for level geometry

### DIFF
--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -430,6 +430,8 @@ MeshInstance3D* Builder::build_entity_mesh(int idx, LMEntity& ent, Node3D* paren
 
 	parent->add_child(mesh_instance);
 
+	// Set the layers that the mesh instance will be rendered in
+	mesh_instance->set_layer_mask(m_loader->get_visual_layer_mask());
 	mesh_instance->set_owner(m_loader->get_owner());
 	mesh_instance->set_name(instance_name);
 

--- a/src/tb_loader.cpp
+++ b/src/tb_loader.cpp
@@ -25,6 +25,8 @@ void TBLoader::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_clip_texture_name"), &TBLoader::get_clip_texture_name);
 	ClassDB::bind_method(D_METHOD("set_skip_texture_name", "option_skip_texture_name"), &TBLoader::set_skip_texture_name);
 	ClassDB::bind_method(D_METHOD("get_skip_texture_name"), &TBLoader::get_skip_texture_name);
+	ClassDB::bind_method(D_METHOD("set_visual_layer_mask", "option_visual_layer_mask"), &TBLoader::set_visual_layer_mask);
+	ClassDB::bind_method(D_METHOD("get_visual_layer_mask"), &TBLoader::get_visual_layer_mask);
 
 	ClassDB::bind_method(D_METHOD("set_entity_common", "entity_common"), &TBLoader::set_entity_common);
 	ClassDB::bind_method(D_METHOD("get_entity_common"), &TBLoader::get_entity_common);
@@ -47,6 +49,7 @@ void TBLoader::_bind_methods()
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_filter_nearest", PROPERTY_HINT_NONE, "Texture Filter Nearest"), "set_filter_nearest", "get_filter_nearest");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "option_clip_texture_name", PROPERTY_HINT_NONE, "Clip Texture"), "set_clip_texture_name", "get_clip_texture_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "option_skip_texture_name", PROPERTY_HINT_NONE, "skip Texture"), "set_skip_texture_name", "get_skip_texture_name");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "option_visual_layer_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_visual_layer_mask", "get_visual_layer_mask");
 
 	ADD_GROUP("Entities", "entity_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "entity_common", PROPERTY_HINT_NONE, "Common Entities"), "set_entity_common", "get_entity_common");
@@ -139,6 +142,16 @@ void TBLoader::set_skip_texture_name(const String& skip_texture_name)
 String TBLoader::get_skip_texture_name()
 {
 	return m_skip_texture_name;
+}
+
+uint32_t TBLoader::get_visual_layer_mask()
+{
+	return m_visual_layer_mask;
+}
+
+void TBLoader::set_visual_layer_mask(uint32_t visual_layer_mask)
+{
+	m_visual_layer_mask = visual_layer_mask;
 }
 
 void TBLoader::set_entity_common(bool enabled)

--- a/src/tb_loader.h
+++ b/src/tb_loader.h
@@ -28,6 +28,7 @@ public:
 	String m_entity_path = "res://entities";
 	String m_clip_texture_name = "";
 	String m_skip_texture_name = "";
+	uint32_t m_visual_layer_mask = 1;
 
 protected:
 	static void _bind_methods();
@@ -57,6 +58,8 @@ public:
 	String get_clip_texture_name();
 	void set_skip_texture_name(const String& skip_texture);
 	String get_skip_texture_name();
+	uint32_t get_visual_layer_mask();
+	void set_visual_layer_mask(uint32_t visual_layer_mask);
 
 	// Entities
 	void set_entity_common(bool enabled);


### PR DESCRIPTION
(last PR for a while, I promise)

This adds the ability to set the visual layer for the level geometry, this is used for various things, such as screen space outlines or decals.