### PR TITLE
feat(builder): should be able to set a custom textures path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 *.obj
 *.os
 .DS_Store
+.vscode

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -577,7 +577,7 @@ String Builder::texture_path(const char* name, const char* extension)
 
 String Builder::material_path(const char* name)
 {
-	auto root_path = m_loader->m_texture_path + name;
+	auto root_path = m_loader->m_texture_path + "/" + name;
 	String material_path;
 
 	if (FileAccess::file_exists(root_path + ".material")) {

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -459,7 +459,7 @@ MeshInstance3D* Builder::build_entity_mesh(int idx, LMEntity& ent, Node3D* paren
 		}
 
 		// Attempt to load material
-		material = material_from_name(m_loader->m_texture_path, tex.name);
+		material = material_from_name(tex.name);
 
 		if (material == nullptr) {
 			// Load texture
@@ -553,7 +553,7 @@ void Builder::load_and_cache_map_textures()
 
 		// Find the texture with a supported extension - stop when it can be loaded
 		for (int ext_i = 0; ext_i < num_extensions; ext_i++) {
-			tex_path = texture_path(m_loader->m_texture_path, tex.name, supported_extensions[ext_i]);
+			tex_path = texture_path(tex.name, supported_extensions[ext_i]);
 			if (resource_loader->exists(tex_path, "CompressedTexture2D")) {
 				m_loaded_map_textures[tex.name] = resource_loader->load(tex_path);
 				has_loaded_texture = true;
@@ -570,14 +570,14 @@ void Builder::load_and_cache_map_textures()
 	}
 }
 
-String Builder::texture_path(const String& texture_path, const char* name, const char* extension)
+String Builder::texture_path(const char* name, const char* extension)
 {
-	return texture_path + "/" + name + "." + extension;
+	return m_loader->m_texture_path + "/" + name + "." + extension;
 }
 
-String Builder::material_path(const String& texture_path, const char* name)
+String Builder::material_path(const char* name)
 {
-	auto root_path = texture_path + name;
+	auto root_path = m_loader->m_texture_path + name;
 	String material_path;
 
 	if (FileAccess::file_exists(root_path + ".material")) {
@@ -597,9 +597,9 @@ Ref<Texture2D> Builder::texture_from_name(const char* name)
 	return VariantCaster<Ref<Texture2D>>::cast(m_loaded_map_textures[name]);
 }
 
-Ref<Material> Builder::material_from_name(const String& texture_path, const char* name)
+Ref<Material> Builder::material_from_name(const char* name)
 {
-	auto path = material_path(texture_path, name);
+	auto path = material_path(name);
 
 	auto resource_loader = ResourceLoader::get_singleton();
 	if (!resource_loader->exists(path)) {

--- a/src/builder.h
+++ b/src/builder.h
@@ -73,8 +73,8 @@ protected:
 protected:
 	void load_and_cache_map_textures();
 
-	static String texture_path(const String& texture_path, const char* name, const char* extension);
-	static String material_path(const String& texture_path, const char* name);
+	String texture_path(const char* name, const char* extension);
+	String material_path(const char* name);
 	Ref<Texture2D> texture_from_name(const char* name);
-	static Ref<Material> material_from_name(const String& texture_path, const char* name);
+	Ref<Material> material_from_name(const char* name);
 };

--- a/src/builder.h
+++ b/src/builder.h
@@ -73,8 +73,8 @@ protected:
 protected:
 	void load_and_cache_map_textures();
 
-	static String texture_path(const char* name, const char* extension);
-	static String material_path(const char* name);
+	static String texture_path(const String& texture_path, const char* name, const char* extension);
+	static String material_path(const String& texture_path, const char* name);
 	Ref<Texture2D> texture_from_name(const char* name);
-	static Ref<Material> material_from_name(const char* name);
+	static Ref<Material> material_from_name(const String& texture_path, const char* name);
 };

--- a/src/tb_loader.cpp
+++ b/src/tb_loader.cpp
@@ -32,6 +32,8 @@ void TBLoader::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_entity_common"), &TBLoader::get_entity_common);
 	ClassDB::bind_method(D_METHOD("set_entity_path", "entity_path"), &TBLoader::set_entity_path);
 	ClassDB::bind_method(D_METHOD("get_entity_path"), &TBLoader::get_entity_path);
+	ClassDB::bind_method(D_METHOD("set_texture_path", "texture_path"), &TBLoader::set_texture_path);
+	ClassDB::bind_method(D_METHOD("get_texture_path"), &TBLoader::get_texture_path);
 
 	ClassDB::bind_method(D_METHOD("clear"), &TBLoader::clear);
 	ClassDB::bind_method(D_METHOD("build_meshes"), &TBLoader::build_meshes);
@@ -54,6 +56,9 @@ void TBLoader::_bind_methods()
 	ADD_GROUP("Entities", "entity_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "entity_common", PROPERTY_HINT_NONE, "Common Entities"), "set_entity_common", "get_entity_common");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "entity_path", PROPERTY_HINT_DIR, "Entity Path"), "set_entity_path", "get_entity_path");
+
+	ADD_GROUP("Textures", "texture_");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "texture_path", PROPERTY_HINT_DIR, "Textures Path"), "set_texture_path", "get_texture_path");
 }
 
 TBLoader::TBLoader()
@@ -172,6 +177,19 @@ void TBLoader::set_entity_path(const String& path)
 String TBLoader::get_entity_path()
 {
 	return m_entity_path;
+}
+
+void TBLoader::set_texture_path(const String& path)
+{
+	if (path.is_empty()) {
+		UtilityFunctions::push_warning("WARNING: texture_path should not be empty");
+	}
+	m_texture_path = path;
+}
+
+String TBLoader::get_texture_path()
+{
+	return m_texture_path;
 }
 
 void TBLoader::clear()

--- a/src/tb_loader.h
+++ b/src/tb_loader.h
@@ -26,6 +26,7 @@ public:
 
 	bool m_entity_common = true;
 	String m_entity_path = "res://entities";
+	String m_texture_path = "res://textures";
 	String m_clip_texture_name = "";
 	String m_skip_texture_name = "";
 	uint32_t m_visual_layer_mask = 1;
@@ -66,6 +67,8 @@ public:
 	bool get_entity_common();
 	void set_entity_path(const String& path);
 	String get_entity_path();
+	void set_texture_path(const String& path);
+	String get_texture_path();
 
 	void clear();
 	void build_meshes();


### PR DESCRIPTION
## Proposal
Hi, 

I never use tbloader or TrenchBroom before this morning and I barely coded in c++ in the last 12 years. 

But this seems like exactly what I needed for my projects. The only con (after 1h of use) was the static `res::textures/` folder path. So I made a quick edit to setup a custom textures path.

This should also close the following issue https://github.com/codecat/godot-tbloader/issues/41. 

## Trenchboom config
![image](https://user-images.githubusercontent.com/1162446/203404399-ef5f7ff9-0309-4966-852b-68cbd936f310.png)
![image](https://user-images.githubusercontent.com/1162446/203404429-6ea0e2ea-cf17-4665-9373-5c03493866de.png)


## Workflow
https://user-images.githubusercontent.com/1162446/203404239-9f63fc37-29fe-46cc-a423-5fae73c2d503.mp4


