### PR TITLE
Fix compilation for master version of godot (soon to be beta 9)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <godot/gdnative_interface.h>
+#include <gdextension_interface.h>
 
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/core/class_db.hpp>
@@ -21,10 +21,10 @@ void unregister_tbloader_types(ModuleInitializationLevel p_level)
 
 extern "C"
 {
-	GDNativeBool GDN_EXPORT tbloader_init(
-		const GDNativeInterface *p_interface,
-		const GDNativeExtensionClassLibraryPtr p_library,
-		GDNativeInitialization *r_initialization
+	GDExtensionBool GDE_EXPORT tbloader_init(
+		const GDExtensionInterface *p_interface,
+		const GDExtensionClassLibraryPtr p_library,
+		GDExtensionInitialization *r_initialization
 	) {
 		GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
 

--- a/src/tb_loader.h
+++ b/src/tb_loader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <godot/gdnative_interface.h>
+#include <gdextension_interface.h>
 
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/core/defs.hpp>


### PR DESCRIPTION
I tested with a master version of godot and tbloader make it crash. Updating godot-cpp it's not enough to make it compile since there was also renames (They have the new names on the README so it was easy). This changes make it work again. I did a quick test and appears to work as before.