### PR TITLE
Added support for texture paths with spaces

### DIFF
--- a/src/map/map_parser.cpp
+++ b/src/map/map_parser.cpp
@@ -84,6 +84,7 @@ bool LMMapParser::load_from_path(const char *map_file) {
 	int c;
 	char buf[255];
 	int buf_head = 0;
+	bool is_quoted = false;
 	while ((c = fgetc(map)) != EOF) {
 		if (c == '\n') {
 			buf[buf_head] = '\0';
@@ -91,12 +92,16 @@ bool LMMapParser::load_from_path(const char *map_file) {
 			buf_head = 0;
 
 			newline();
-		} else if (isspace(c)) {
+		} else if (isspace(c) && !is_quoted) {
 			buf[buf_head] = '\0';
 			token(buf);
 			buf_head = 0;
 		} else {
-			buf[buf_head++] = c;
+			if (scope == PS_TEXTURE && c == '"') {
+				is_quoted = !is_quoted;
+			} else {
+				buf[buf_head++] = c;
+			}
 		}
 	}
 
@@ -123,6 +128,7 @@ void LMMapParser::load_from_godot_file(godot::Ref<godot::FileAccess> f) {
 	int c;
 	char buf[255];
 	int buf_head = 0;
+	bool is_quoted = false;
 	while (!f->eof_reached()) {
 		c = (int)f->get_8();
 
@@ -132,12 +138,16 @@ void LMMapParser::load_from_godot_file(godot::Ref<godot::FileAccess> f) {
 			buf_head = 0;
 
 			newline();
-		} else if (isspace(c)) {
+		} else if (isspace(c) && !is_quoted) {
 			buf[buf_head] = '\0';
 			token(buf);
 			buf_head = 0;
 		} else {
-			buf[buf_head++] = c;
+			if (scope == PS_TEXTURE && c == '"') {
+				is_quoted = !is_quoted;
+			} else {
+				buf[buf_head++] = c;
+			}
 		}
 	}
 }


### PR DESCRIPTION
First congratulation on the great plugin, it works really well!

While testing a few maps I noticed that TrenchBroom exports texture paths with spaces in quotes. Unfortunately the current tokenizer for the map format ignored the quotes and cut the paths at the first space.

I tried to fix this by allowing the tokenizer to skip spaces while parsing the texture scope. It is not the most elegant solution due to introducing scope dependence in the tokenizer but else the entity parsing code was impacted, but it allows usage of spaces in texture filenames now.