### PR TITLE
fix compatibility for Godot 4.1

### DIFF
--- a/addons/tbloader/tbloader.gdextension
+++ b/addons/tbloader/tbloader.gdextension
@@ -1,5 +1,6 @@
 [configuration]
 entry_symbol = "tbloader_init"
+compatibility_minimum = 4.1
 
 [libraries]
 windows.64 = "bin/tbloader.windows.x86_64.dll"


### PR DESCRIPTION
Fixes #82 & #81 

I fixed it by adding `compatibility_minimum = 4.1` line to _tbloader.gdextension_ file and rebuilding /bin libs by calling
`python -m SCons platform=<platform>` (tested on Windows so i typed platform=windows)