### PR TITLE
Update TB GameConfig file to version 8

### DIFF
--- a/tb-gameconfig/GameConfig.cfg
+++ b/tb-gameconfig/GameConfig.cfg
@@ -1,5 +1,5 @@
 {
-    version: 4,
+    version: 8,
     name: "Godot",
     icon: "Icon.png",
     "fileformats": [
@@ -10,8 +10,8 @@
         "packageformat": { "extension": "pak", "format": "idpak" }
     },
     "textures": {
-        "package": { "type": "directory", "root": "textures" },
-        "format": { "extensions": ["png", "dds", "tga", "jpg", "jpeg", "bmp", "webp", "exr", "hdr"], "format": "image" },
+        "root": "textures",
+        "extensions": ["png", "dds", "tga", "jpg", "jpeg", "bmp", "webp", "exr", "hdr"],
         "attribute": "_tb_textures"
     },
     "entities": {


### PR DESCRIPTION
[TrenchBroom 2024.1](https://github.com/TrenchBroom/TrenchBroom/releases/tag/v2024.1) deprecated game configuration files with version 6 or lower.

This should fix #96.