### PR TITLE
Add UV2 unwrap texel size property to TBLoader class

### DIFF
--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -519,7 +519,7 @@ MeshInstance3D* Builder::build_entity_mesh(int idx, LMEntity& ent, Node3D* paren
 
 	// Unwrap UV2's if needed
 	if (m_loader->m_lighting_unwrap_uv2) {
-		mesh->lightmap_unwrap(mesh_instance->get_global_transform(), 0.05);
+		mesh->lightmap_unwrap(mesh_instance->get_global_transform(), m_loader->m_lighting_unwrap_texel_size);
 		mesh_instance->set_gi_mode(GeometryInstance3D::GI_MODE_STATIC);
 	}
 

--- a/src/tb_loader.cpp
+++ b/src/tb_loader.cpp
@@ -14,6 +14,8 @@ void TBLoader::_bind_methods()
 
 	ClassDB::bind_method(D_METHOD("set_lighting_unwrap_uv2", "lighting_unwrap_uv2"), &TBLoader::set_lighting_unwrap_uv2);
 	ClassDB::bind_method(D_METHOD("get_lighting_unwrap_uv2"), &TBLoader::get_lighting_unwrap_uv2);
+	ClassDB::bind_method(D_METHOD("set_lighting_unwrap_texel_size", "lighting_unwrap_texel_size"), &TBLoader::set_lighting_unwrap_texel_size);
+	ClassDB::bind_method(D_METHOD("get_lighting_unwrap_texel_size"), &TBLoader::get_lighting_unwrap_texel_size);
 
 	ClassDB::bind_method(D_METHOD("set_collision", "option_collision"), &TBLoader::set_collision);
 	ClassDB::bind_method(D_METHOD("get_collision"), &TBLoader::get_collision);
@@ -44,6 +46,7 @@ void TBLoader::_bind_methods()
 
 	ADD_GROUP("Lighting", "lighting_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "lighting_unwrap_uv2", PROPERTY_HINT_NONE, "Unwrap UV2"), "set_lighting_unwrap_uv2", "get_lighting_unwrap_uv2");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lighting_unwrap_texel_size", PROPERTY_HINT_NONE, "Unwrap Texel Size"), "set_lighting_unwrap_texel_size", "get_lighting_unwrap_texel_size");
 
 	ADD_GROUP("Options", "option_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_collision", PROPERTY_HINT_NONE, "Collision"), "set_collision", "get_collision");
@@ -97,6 +100,16 @@ void TBLoader::set_lighting_unwrap_uv2(bool enabled)
 bool TBLoader::get_lighting_unwrap_uv2()
 {
 	return m_lighting_unwrap_uv2;
+}
+
+void TBLoader::set_lighting_unwrap_texel_size(double size)
+{
+	m_lighting_unwrap_texel_size = size;
+}
+
+double TBLoader::get_lighting_unwrap_texel_size()
+{
+	return m_lighting_unwrap_texel_size;
 }
 
 void TBLoader::set_collision(bool enabled)

--- a/src/tb_loader.h
+++ b/src/tb_loader.h
@@ -19,6 +19,7 @@ public:
 	int m_inverse_scale = 16;
 
 	bool m_lighting_unwrap_uv2 = false;
+	double m_lighting_unwrap_texel_size = 0.2;
 
 	bool m_collision = true;
 	bool m_skip_hidden_layers = true;
@@ -47,6 +48,8 @@ public:
 	// Lighting
 	void set_lighting_unwrap_uv2(bool enabled);
 	bool get_lighting_unwrap_uv2();
+	void set_lighting_unwrap_texel_size(double size);
+	double get_lighting_unwrap_texel_size();
 
 	// Options
 	void set_collision(bool enabled);


### PR DESCRIPTION
This PR adds a UV2 unwrap texel size property to the TBLoader class. I noticed that it originally used a default of `0.05`, which would make my final production builds quite large. This removes that hardcoded value and uses a property on the TBLoader class instead.