### PR TITLE
Add the ability to set a "Material Template" for textures

### DIFF
--- a/src/tb_loader.cpp
+++ b/src/tb_loader.cpp
@@ -34,8 +34,13 @@ void TBLoader::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_entity_common"), &TBLoader::get_entity_common);
 	ClassDB::bind_method(D_METHOD("set_entity_path", "entity_path"), &TBLoader::set_entity_path);
 	ClassDB::bind_method(D_METHOD("get_entity_path"), &TBLoader::get_entity_path);
+
 	ClassDB::bind_method(D_METHOD("set_texture_path", "texture_path"), &TBLoader::set_texture_path);
 	ClassDB::bind_method(D_METHOD("get_texture_path"), &TBLoader::get_texture_path);
+	ClassDB::bind_method(D_METHOD("set_material_template", "material"), &TBLoader::set_material_template);
+	ClassDB::bind_method(D_METHOD("get_material_template"), &TBLoader::get_material_template);
+	ClassDB::bind_method(D_METHOD("set_material_texture_path", "texture_path"), &TBLoader::set_material_texture_path);
+	ClassDB::bind_method(D_METHOD("get_material_texture_path"), &TBLoader::get_material_texture_path);
 
 	ClassDB::bind_method(D_METHOD("clear"), &TBLoader::clear);
 	ClassDB::bind_method(D_METHOD("build_meshes"), &TBLoader::build_meshes);
@@ -62,6 +67,8 @@ void TBLoader::_bind_methods()
 
 	ADD_GROUP("Textures", "texture_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "texture_path", PROPERTY_HINT_DIR, "Textures Path"), "set_texture_path", "get_texture_path");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture_material_template", PROPERTY_HINT_RESOURCE_TYPE, "Material"), "set_material_template", "get_material_template");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "texture_material_texture_path", PROPERTY_HINT_NONE, "Material Texture Property Path"), "set_material_texture_path", "get_material_texture_path");
 }
 
 TBLoader::TBLoader()
@@ -203,6 +210,26 @@ void TBLoader::set_texture_path(const String& path)
 String TBLoader::get_texture_path()
 {
 	return m_texture_path;
+}
+
+void TBLoader::set_material_template(const Ref<Material>& material)
+{
+	m_material_template = material;
+}
+
+Ref<Material> TBLoader::get_material_template()
+{
+	return m_material_template;
+}
+
+void TBLoader::set_material_texture_path(const String& texture_path)
+{
+	m_material_texture_path = texture_path;
+}
+
+String TBLoader::get_material_texture_path()
+{
+	return m_material_texture_path;
 }
 
 void TBLoader::clear()

--- a/src/tb_loader.h
+++ b/src/tb_loader.h
@@ -28,6 +28,8 @@ public:
 	bool m_entity_common = true;
 	String m_entity_path = "res://entities";
 	String m_texture_path = "res://textures";
+	Ref<Material> m_material_template;
+	String m_material_texture_path = "albedo_texture";
 	String m_clip_texture_name = "";
 	String m_skip_texture_name = "";
 	uint32_t m_visual_layer_mask = 1;
@@ -70,8 +72,14 @@ public:
 	bool get_entity_common();
 	void set_entity_path(const String& path);
 	String get_entity_path();
+
+	// Textures
 	void set_texture_path(const String& path);
 	String get_texture_path();
+	void set_material_template(const Ref<Material>& material);
+	Ref<Material> get_material_template();
+	void set_material_texture_path(const String& texture_path);
+	String get_material_texture_path();
 
 	void clear();
 	void build_meshes();


### PR DESCRIPTION
Allow for a default material to be used instead of generating a new StandardMaterial3D when building a texture without a `.material`.

This should close both #93 and #62.

## Material Template
If `Material Template` is defined, a duplicate of it will be used instead of a new StandardMaterial3D.

## Material Texture Path
The `Material Texture Path` defines the property path the texture should be assigned to. So for a custom `StandardMaterial3D`, this could be `albedo_texture`. If a `ShaderMaterial` is used, this path should be the path to the shader uniform, such as `shader_parameter/my_texture`.

## Demonstration
![Godot_v4 3-stable_win64_a6X8mehuy8](https://github.com/user-attachments/assets/f6d84e35-0957-4e74-bb54-73502548c7ee)
