### PR TITLE
Add "No Collision" Brush Entity (+Skip Empty Meshes checkbox)

### DIFF
--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -66,7 +66,7 @@ void Builder::build_map()
 	}
 }
 
-void Builder::build_worldspawn(int idx, LMEntity& ent, bool visible_only)
+void Builder::build_worldspawn(int idx, LMEntity& ent, bool no_collision)
 {
 	// Create node for this entity
 	auto container_node = memnew(Node3D());
@@ -76,7 +76,7 @@ void Builder::build_worldspawn(int idx, LMEntity& ent, bool visible_only)
 	// Decide generated collision type
 	ColliderType collider = ColliderType::None;
 	ColliderShape collider_shape = ColliderShape::Concave;
-	if (!visible_only && m_loader->m_collision) {
+	if (!no_collision && m_loader->m_collision) {
 		collider = ColliderType::Static;
 		collider_shape = ColliderShape::Concave;
 	}
@@ -130,7 +130,7 @@ void Builder::build_entity(int idx, LMEntity& ent, const String& classname)
 			return;
 		}
 
-		if (classname == "visibleonly") {
+		if (classname == "nocollision") {
 			build_worldspawn(idx, ent, true);
 			return;
 		}

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -66,7 +66,7 @@ void Builder::build_map()
 	}
 }
 
-void Builder::build_worldspawn(int idx, LMEntity& ent)
+void Builder::build_worldspawn(int idx, LMEntity& ent, bool visible_only)
 {
 	// Create node for this entity
 	auto container_node = memnew(Node3D());
@@ -76,7 +76,7 @@ void Builder::build_worldspawn(int idx, LMEntity& ent)
 	// Decide generated collision type
 	ColliderType collider = ColliderType::None;
 	ColliderShape collider_shape = ColliderShape::Concave;
-	if (m_loader->m_collision) {
+	if (!visible_only && m_loader->m_collision) {
 		collider = ColliderType::Static;
 		collider_shape = ColliderShape::Concave;
 	}
@@ -115,7 +115,7 @@ void Builder::build_entity(int idx, LMEntity& ent, const String& classname)
 				return;
 			}
 		}
-		build_worldspawn(idx, ent);
+		build_worldspawn(idx, ent, false);
 		return;
 	}
 
@@ -127,6 +127,11 @@ void Builder::build_entity(int idx, LMEntity& ent, const String& classname)
 
 		if (classname == "area") {
 			build_entity_area(idx, ent);
+			return;
+		}
+
+		if (classname == "visibleonly") {
+			build_worldspawn(idx, ent, true);
 			return;
 		}
 

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -529,18 +529,25 @@ MeshInstance3D* Builder::build_entity_mesh(int idx, LMEntity& ent, Node3D* paren
 	}
 
 	// Create collisions if needed
-	switch (coltype) {
-	case ColliderType::Mesh:
-		add_collider_from_mesh(parent, collision_mesh, colshape);
-		break;
+	if (!m_loader->m_skip_empty_meshes || collision_mesh->get_surface_count() > 0) {
+		switch (coltype) {
+		case ColliderType::Mesh:
+			add_collider_from_mesh(parent, collision_mesh, colshape);
+			break;
 
-	case ColliderType::Static:
-		StaticBody3D* static_body = memnew(StaticBody3D());
-		static_body->set_name(String(mesh_instance->get_name()) + "_col");
-		parent->add_child(static_body, true);
-		static_body->set_owner(m_loader->get_owner());
-		add_collider_from_mesh(static_body, collision_mesh, colshape);
-		break;
+		case ColliderType::Static:
+			StaticBody3D* static_body = memnew(StaticBody3D());
+			static_body->set_name(String(mesh_instance->get_name()) + "_col");
+			parent->add_child(static_body, true);
+			static_body->set_owner(m_loader->get_owner());
+			add_collider_from_mesh(static_body, collision_mesh, colshape);
+			break;
+		}
+	}
+
+	// Remove the empty mesh instances if enabled
+	if (m_loader->m_skip_empty_meshes && mesh->get_surface_count() == 0) {
+		parent->remove_child(mesh_instance);
 	}
 
 	return mesh_instance;

--- a/src/builder.h
+++ b/src/builder.h
@@ -52,7 +52,7 @@ public:
 	void load_map(const String& path);
 	void build_map();
 
-	void build_worldspawn(int idx, LMEntity& ent);
+	void build_worldspawn(int idx, LMEntity& ent, bool visible_only);
 	void build_brush(int idx, Node3D* node, LMEntity& ent);
 
 	void build_entity(int idx, LMEntity& ent, const String& classname);

--- a/src/builder.h
+++ b/src/builder.h
@@ -52,7 +52,7 @@ public:
 	void load_map(const String& path);
 	void build_map();
 
-	void build_worldspawn(int idx, LMEntity& ent, bool visible_only);
+	void build_worldspawn(int idx, LMEntity& ent, bool no_collision);
 	void build_brush(int idx, Node3D* node, LMEntity& ent);
 
 	void build_entity(int idx, LMEntity& ent, const String& classname);

--- a/src/tb_loader.cpp
+++ b/src/tb_loader.cpp
@@ -53,7 +53,7 @@ void TBLoader::_bind_methods()
 	ADD_GROUP("Options", "option_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_collision", PROPERTY_HINT_NONE, "Collision"), "set_collision", "get_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_skip_hidden_layers", PROPERTY_HINT_NONE, "Skip Hidden Layers"), "set_skip_hidden_layers", "get_skip_hidden_layers");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_skip_empty_meshes", PROPERTY_HINT_NONE, "Skip Empty Meshes"), "set_skip_empty_meshes", "get_skip_hidden_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_skip_empty_meshes", PROPERTY_HINT_NONE, "Skip Empty Meshes"), "set_skip_empty_meshes", "get_skip_empty_meshes");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_filter_nearest", PROPERTY_HINT_NONE, "Texture Filter Nearest"), "set_filter_nearest", "get_filter_nearest");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "option_clip_texture_name", PROPERTY_HINT_NONE, "Clip Texture"), "set_clip_texture_name", "get_clip_texture_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "option_skip_texture_name", PROPERTY_HINT_NONE, "skip Texture"), "set_skip_texture_name", "get_skip_texture_name");

--- a/src/tb_loader.cpp
+++ b/src/tb_loader.cpp
@@ -21,6 +21,8 @@ void TBLoader::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_collision"), &TBLoader::get_collision);
 	ClassDB::bind_method(D_METHOD("set_skip_hidden_layers", "option_skip_hidden_layers"), &TBLoader::set_skip_hidden_layers);
 	ClassDB::bind_method(D_METHOD("get_skip_hidden_layers"), &TBLoader::get_skip_hidden_layers);
+	ClassDB::bind_method(D_METHOD("set_skip_empty_meshes", "option_skip_empty_meshes"), &TBLoader::set_skip_empty_meshes);
+	ClassDB::bind_method(D_METHOD("get_skip_empty_meshes"), &TBLoader::get_skip_empty_meshes);
 	ClassDB::bind_method(D_METHOD("set_filter_nearest", "option_filter_nearest"), &TBLoader::set_filter_nearest);
 	ClassDB::bind_method(D_METHOD("get_filter_nearest"), &TBLoader::get_filter_nearest);
 	ClassDB::bind_method(D_METHOD("set_clip_texture_name", "option_clip_texture_name"), &TBLoader::set_clip_texture_name);
@@ -51,6 +53,7 @@ void TBLoader::_bind_methods()
 	ADD_GROUP("Options", "option_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_collision", PROPERTY_HINT_NONE, "Collision"), "set_collision", "get_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_skip_hidden_layers", PROPERTY_HINT_NONE, "Skip Hidden Layers"), "set_skip_hidden_layers", "get_skip_hidden_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_skip_empty_meshes", PROPERTY_HINT_NONE, "Skip Empty Meshes"), "set_skip_empty_meshes", "get_skip_hidden_layers");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "option_filter_nearest", PROPERTY_HINT_NONE, "Texture Filter Nearest"), "set_filter_nearest", "get_filter_nearest");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "option_clip_texture_name", PROPERTY_HINT_NONE, "Clip Texture"), "set_clip_texture_name", "get_clip_texture_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "option_skip_texture_name", PROPERTY_HINT_NONE, "skip Texture"), "set_skip_texture_name", "get_skip_texture_name");
@@ -130,6 +133,16 @@ void TBLoader::set_skip_hidden_layers(bool enabled)
 bool TBLoader::get_skip_hidden_layers()
 {
 	return m_skip_hidden_layers;
+}
+
+void TBLoader::set_skip_empty_meshes(bool enabled)
+{
+	m_skip_empty_meshes = enabled;
+}
+
+bool TBLoader::get_skip_empty_meshes()
+{
+	return m_skip_empty_meshes;
 }
 
 void TBLoader::set_filter_nearest(bool enabled)

--- a/src/tb_loader.h
+++ b/src/tb_loader.h
@@ -23,6 +23,7 @@ public:
 
 	bool m_collision = true;
 	bool m_skip_hidden_layers = true;
+	bool m_skip_empty_meshes = true;
 	bool m_filter_nearest = false;
 
 	bool m_entity_common = true;
@@ -56,6 +57,8 @@ public:
 	bool get_collision();
 	void set_skip_hidden_layers(bool enabled);
 	bool get_skip_hidden_layers();
+	void set_skip_empty_meshes(bool enabled);
+	bool get_skip_empty_meshes();
 	void set_filter_nearest(bool enabled);
 	bool get_filter_nearest();
 	void set_clip_texture_name(const String& clip_texture);

--- a/tb-gameconfig/Godot.fgd
+++ b/tb-gameconfig/Godot.fgd
@@ -12,7 +12,7 @@
 
 @SolidClass = area : "Area" []
 
-@SolidClass = visibleonly : "Visible only" []
+@SolidClass = nocollision : "No collision" []
 
 @PointClass base(Angle) size(-16 -16 -16, 16 16 16) color(0 255 0) = player : "Player" []
 

--- a/tb-gameconfig/Godot.fgd
+++ b/tb-gameconfig/Godot.fgd
@@ -12,6 +12,8 @@
 
 @SolidClass = area : "Area" []
 
+@SolidClass = visibleonly : "Visible only" []
+
 @PointClass base(Angle) size(-16 -16 -16, 16 16 16) color(0 255 0) = player : "Player" []
 
 @PointClass size(-4 -4 -4, 4 4 4) color(255 255 0) = light : "Light" [


### PR DESCRIPTION
## No Collision Brush Entity
This adds a brush entity that doesn't generate collision for the brush. Useful in combination with clip textures to configure geometry for certain things (like giving stairs ramp-like collision).

I named it "No Collision" since that seemed like a more descriptive name, but maybe it should be named "Illusionary" to be more consistent with the Valve/Qodot name?

## Skip Empty Meshes
When generating collision nodes with an empty ArrayMesh, Godot will generate error messages. To avoid these, I also added an optional feature "Skip Empty Meshes." This is a checkbox that will prevent empty meshes (both visual & collision) from being added to the node tree. 

