### PR TITLE
Add the ability to set the Collision Layer Mask for generated collision

### DIFF
--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -578,6 +578,7 @@ MeshInstance3D* Builder::build_entity_mesh(int idx, LMEntity& ent, Node3D* paren
 		case ColliderType::Static:
 			StaticBody3D* static_body = memnew(StaticBody3D());
 			static_body->set_name(String(mesh_instance->get_name()) + "_col");
+			static_body->set_collision_layer(m_loader->get_collision_layer_mask());
 			parent->add_child(static_body, true);
 			static_body->set_owner(m_loader->get_owner());
 			add_collider_from_mesh(static_body, collision_mesh, colshape);

--- a/src/tb_loader.cpp
+++ b/src/tb_loader.cpp
@@ -31,6 +31,8 @@ void TBLoader::_bind_methods()
 	ClassDB::bind_method(D_METHOD("get_skip_texture_name"), &TBLoader::get_skip_texture_name);
 	ClassDB::bind_method(D_METHOD("set_visual_layer_mask", "option_visual_layer_mask"), &TBLoader::set_visual_layer_mask);
 	ClassDB::bind_method(D_METHOD("get_visual_layer_mask"), &TBLoader::get_visual_layer_mask);
+	ClassDB::bind_method(D_METHOD("set_collision_layer_mask", "option_collision_layer_mask"), &TBLoader::set_collision_layer_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_layer_mask"), &TBLoader::get_collision_layer_mask);
 
 	ClassDB::bind_method(D_METHOD("set_entity_common", "entity_common"), &TBLoader::set_entity_common);
 	ClassDB::bind_method(D_METHOD("get_entity_common"), &TBLoader::get_entity_common);
@@ -63,6 +65,7 @@ void TBLoader::_bind_methods()
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "option_clip_texture_name", PROPERTY_HINT_NONE, "Clip Texture"), "set_clip_texture_name", "get_clip_texture_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "option_skip_texture_name", PROPERTY_HINT_NONE, "skip Texture"), "set_skip_texture_name", "get_skip_texture_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "option_visual_layer_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_visual_layer_mask", "get_visual_layer_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "option_collision_layer_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer_mask", "get_collision_layer_mask");
 
 	ADD_GROUP("Entities", "entity_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "entity_common", PROPERTY_HINT_NONE, "Common Entities"), "set_entity_common", "get_entity_common");
@@ -190,6 +193,16 @@ uint32_t TBLoader::get_visual_layer_mask()
 void TBLoader::set_visual_layer_mask(uint32_t visual_layer_mask)
 {
 	m_visual_layer_mask = visual_layer_mask;
+}
+
+uint32_t TBLoader::get_collision_layer_mask()
+{
+	return m_collision_layer_mask;
+}
+
+void TBLoader::set_collision_layer_mask(uint32_t collision_layer_mask)
+{
+	m_collision_layer_mask = collision_layer_mask;
 }
 
 void TBLoader::set_entity_common(bool enabled)

--- a/src/tb_loader.h
+++ b/src/tb_loader.h
@@ -34,6 +34,7 @@ public:
 	String m_clip_texture_name = "";
 	String m_skip_texture_name = "";
 	uint32_t m_visual_layer_mask = 1;
+	uint32_t m_collision_layer_mask = 1;
 
 protected:
 	static void _bind_methods();
@@ -69,6 +70,8 @@ public:
 	String get_skip_texture_name();
 	uint32_t get_visual_layer_mask();
 	void set_visual_layer_mask(uint32_t visual_layer_mask);
+	uint32_t get_collision_layer_mask();
+	void set_collision_layer_mask(uint32_t collision_layer_mask);
 
 	// Entities
 	void set_entity_common(bool enabled);


### PR DESCRIPTION
As the title states, this simply adds the option to edit the collision mask for the generated collision nodes.

![mUTB61jDtk](https://github.com/user-attachments/assets/80f102b9-d907-4264-b2d9-46c42be90f6f)
