### PR TITLE
Allow materials to be discovered in res:// outside editor

### DIFF
--- a/src/builder.h
+++ b/src/builder.h
@@ -77,4 +77,8 @@ protected:
 	String material_path(const char* name);
 	Ref<Texture2D> texture_from_name(const char* name);
 	Ref<Material> material_from_name(const char* name);
+
+protected:
+	static String sanitized_dir(const char* name);
+	static String sanitized_dir(String name);
 };


### PR DESCRIPTION
Fix for https://github.com/codecat/godot-tbloader/issues/88

When a Godot project is exported (and during regular run-from-editor), assets are binary-packed and lose their typical filesystem structure. FileAccess cannot read binary assets from res:// due to this.

The static functions are just helpers as I've made a fair few modifications for my own uses, but I've cherry picked the code to specifically solve this issue. Feel free to remove them if consistency with the rest of the codebase is desired.